### PR TITLE
change-timings-for-kh-namespace-kuberhealthy-check

### DIFF
--- a/resources/namespace-check.yaml
+++ b/resources/namespace-check.yaml
@@ -5,8 +5,8 @@ metadata:
   name: namespace-kh-check
   namespace: kuberhealthy
 spec:
-  runInterval: 30s # The interval that Kuberhealthy will run your check on
-  timeout: 2m # After this much time, Kuberhealthy will kill your check and consider it "failed"
+  runInterval: 5m # The interval that Kuberhealthy will run your check on
+  timeout: 10m # After this much time, Kuberhealthy will kill your check and consider it "failed"
   podSpec: # The exact pod spec that will run.  All normal pod spec is valid here.
     containers:
       - env: [] # Environment variables are optional but a recommended way to configure check behavior


### PR DESCRIPTION
Why [Kuberhealthy Alerts Review#4670](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4670)
To make namespace checks less frequent