### PR TITLE
slight-adjustment-to-checkout-time-namespace-check

### DIFF
--- a/resources/namespace-check.yaml
+++ b/resources/namespace-check.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kuberhealthy
 spec:
   runInterval: 5m # The interval that Kuberhealthy will run your check on
-  timeout: 10m # After this much time, Kuberhealthy will kill your check and consider it "failed"
+  timeout: 15m # After this much time, Kuberhealthy will kill your check and consider it "failed"
   podSpec: # The exact pod spec that will run.  All normal pod spec is valid here.
     containers:
       - env: [] # Environment variables are optional but a recommended way to configure check behavior


### PR DESCRIPTION
Why [Kuberhealthy Alerts Review#4670](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4670)
To make namespace checks less frequent - to bring in line with other checks