### PR TITLE
Upgrade chart version from 87 > 92

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "helm_release" "kuberhealthy" {
   namespace  = kubernetes_namespace.kuberhealthy.id
   repository = "https://kuberhealthy.github.io/kuberhealthy/helm-repos/"
   chart      = "kuberhealthy"
-  version    = "87"
+  version    = "92"
 
   set {
     name  = "auditFromCache"


### PR DESCRIPTION
New chart migrates PodDisruptionBudget API from `v1beta1` to `policy/v1`