### PR TITLE
Change restricted to privileged

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "kubernetes_namespace" "kuberhealthy" {
       "component"                                      = "kuberhealthy"
       "cloud-platform.justice.gov.uk/is-production"    = "true"
       "cloud-platform.justice.gov.uk/environment-name" = "production"
-      "pod-security.kubernetes.io/enforce"             = "restricted"
+      "pod-security.kubernetes.io/enforce"             = "privileged"
     }
 
     annotations = {


### PR DESCRIPTION
This PP changes the PSA label from restrcited to privileged

During test cluster creation, the gatekeeper module has dependency over other modules and hence kuberhealthy is installed before the gatekeeper mutations comes in. In current state and in 1.25, kuberhealthy pods throw errror ``` Error creating: pods "kuberhealthy-85589cc897-xxfvw" is forbidden: violates PodSecurity "restricted:latest": unrestricted capabilities (container "kuberhealthy" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container "kuberhealthy" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")```

The chart doesnt have the feature to explicitly set the seccompProfile or capabilities. hence, update the namespace with privileged so kuberhealthy can be installed independent of gatekeeper.

This is only a temporary solution to open the privileges for kuberhealthy until the cluster creation order for components is changed to install gatekeeper first before all the components which depend on the gk mutations 
