### PR TITLE
Add dependency chain for service account and cluster role binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ No modules.
 |------|------|
 | [helm_release.kuberhealthy](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.namespace_check](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
+| [kubectl_manifest.namespacecheck_rule_alert_cr](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
 | [kubectl_manifest.namespacecheck_rule_alert_crb](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
-| [kubectl_manifest.namespacecheck_rule_alert_role](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
 | [kubectl_manifest.namespacecheck_rule_alert_sa](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
 | [kubernetes_namespace.kuberhealthy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ No modules.
 |------|------|
 | [helm_release.kuberhealthy](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.namespace_check](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
-| [kubectl_manifest.namespacecheck_rule_alert](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
+| [kubectl_manifest.namespacecheck_rule_alert_crb](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
+| [kubectl_manifest.namespacecheck_rule_alert_role](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
+| [kubectl_manifest.namespacecheck_rule_alert_sa](https://registry.terraform.io/providers/alekc/kubectl/2.0.4/docs/resources/manifest) | resource |
 | [kubernetes_namespace.kuberhealthy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -61,17 +61,23 @@ resource "helm_release" "kuberhealthy" {
 resource "kubectl_manifest" "namespacecheck_rule_alert_crb" {
   yaml_body = file("${path.module}/resources/cluster-role-binding.yaml")
 
+  wait = true
+
   depends_on = [helm_release.kuberhealthy]
 }
 
 resource "kubectl_manifest" "namespacecheck_rule_alert_cr" {
   yaml_body = file("${path.module}/resources/cluster-role.yaml")
 
+  wait = true
+
   depends_on = [helm_release.kuberhealthy]
 }
 
 resource "kubectl_manifest" "namespacecheck_rule_alert_sa" {
   yaml_body = file("${path.module}/resources/serviceaccount.yaml")
+
+  wait = true
 
   depends_on = [
     helm_release.kuberhealthy,

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "kubectl_manifest" "namespacecheck_rule_alert_crb" {
   depends_on = [helm_release.kuberhealthy]
 }
 
-resource "kubectl_manifest" "namespacecheck_rule_alert_role" {
+resource "kubectl_manifest" "namespacecheck_rule_alert_cr" {
   yaml_body = file("${path.module}/resources/cluster-role.yaml")
 
   depends_on = [helm_release.kuberhealthy]

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "kubectl_manifest" "namespacecheck_rule_alert_sa" {
 
   depends_on = [
     helm_release.kuberhealthy,
-    kubectl_manifest.namespacecheck_rule_alertcrb
+    kubectl_manifest.namespacecheck_rule_alert_crb
   ]
 }
 


### PR DESCRIPTION
Adds a dependency chain so that the cluster role binding won't be deleted before the serviceaccount.