### PR TITLE
Cluster critical priority

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,11 @@ resource "helm_release" "kuberhealthy" {
     value = "false"
   }
 
+  set {
+    name = "deployment.env.DAEMONSET_PRIORITY_CLASS_NAME"
+    value = "system-cluster-critical"
+  }
+
   lifecycle {
     ignore_changes = [keyring]
   }

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "kuberhealthy" {
 
   set {
     name = "check.daemonset.extraEnvs.DAEMONSET_PRIORITY_CLASS_NAME"
-    value = "system-cluster-critical"
+    value = "node-critical"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "kuberhealthy" {
 
   set {
     name = "check.daemonset.extraEnvs.DAEMONSET_PRIORITY_CLASS_NAME"
-    value = "node-critical"
+    value = "cluster-critical"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "helm_release" "kuberhealthy" {
   }
 
   set {
-    name = "deployment.env.DAEMONSET_PRIORITY_CLASS_NAME"
+    name = "check.daemonset.extraEnvs.DAEMONSET_PRIORITY_CLASS_NAME"
     value = "system-cluster-critical"
   }
 


### PR DESCRIPTION
This change will make the kuberhealthy daemonset tests run with priority 'cluster-critical'.
This will mean the tests run at a similar priority level to Cloud Platform's pods, and should stop the failing tests. 

This has been tested on test cluster - screenshot attached
<img width="543" alt="Screenshot 2024-08-15 at 15 34 40" src="https://github.com/user-attachments/assets/459d4bb9-137d-4de5-94c1-11da8ec44795">
